### PR TITLE
Add `#![forbid(unsafe_code)]`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@
 #![cfg_attr(feature = "bench", doc(include = "../README.md"))]
 // ^ make sure we can test our README.md.
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// No `unsafe` please.  If `unsafe` is really needed, then please
+// consider encapsulating it in a separate crates.io crate.
+#![forbid(unsafe_code)]
 
 // Re-exported dependencies.
 #[cfg(feature = "bmp")]


### PR DESCRIPTION
The newly added `#![forbid(unsafe_code)]` directive serves two purposes:

* It explicitly documents the current state of the crate (i.e. currently there is no `unsafe`) which helps security reviewers to check the overall safety profile / approach of the crate.
* It adds an extra speed bump in case `unsafe` PRs are considered in the future. Hopefully in most cases `unsafe` can be encapsulated in separate (small, auditable) crates that `qr_code` can depend on (and the `forbid` directive can give a gentle nudge in this direction).