### PR TITLE
Increase test coverage

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,4 @@
 use std::convert::TryInto;
-use std::fmt::Display;
 
 // TODO remove this, use try_into wher as_* is used
 
@@ -20,21 +19,6 @@ pub trait As {
     fn as_u32(self) -> u32;
     fn as_usize(self) -> usize;
     fn as_isize(self) -> isize;
-}
-
-trait ExpectOrOverflow {
-    type Output;
-    fn expect_or_overflow<D: Display>(self, value: D, ty: &str) -> Self::Output;
-}
-
-impl<T> ExpectOrOverflow for Option<T> {
-    type Output = T;
-    fn expect_or_overflow<D: Display>(self, value: D, ty: &str) -> Self::Output {
-        match self {
-            Some(v) => v,
-            None => panic!("{} overflows {}", value, ty),
-        }
-    }
 }
 
 macro_rules! impl_as {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -16,9 +16,7 @@ impl Truncate for u16 {
 pub trait As {
     fn as_u16(self) -> u16;
     fn as_i16(self) -> i16;
-    fn as_u32(self) -> u32;
     fn as_usize(self) -> usize;
-    fn as_isize(self) -> isize;
 }
 
 macro_rules! impl_as {
@@ -33,15 +31,7 @@ macro_rules! impl_as {
                 self.try_into().unwrap()
             }
 
-            fn as_u32(self) -> u32 {
-                self.try_into().unwrap()
-            }
-
             fn as_usize(self) -> usize {
-                self.try_into().unwrap()
-            }
-
-            fn as_isize(self) -> isize {
                 self.try_into().unwrap()
             }
         }
@@ -54,14 +44,8 @@ macro_rules! impl_as {
             fn as_i16(self) -> i16 {
                 self as i16
             }
-            fn as_u32(self) -> u32 {
-                self as u32
-            }
             fn as_usize(self) -> usize {
                 self as usize
-            }
-            fn as_isize(self) -> isize {
-                self as isize
             }
         }
     };
@@ -70,4 +54,3 @@ macro_rules! impl_as {
 impl_as!(i16);
 impl_as!(u32);
 impl_as!(usize);
-impl_as!(isize);


### PR DESCRIPTION
@RCasatta, can you PTAL?

This PR improves the test coverage by a tiny bit by removing dead code and adding a few simple tests.

Line coverage before the PR: 95.13%  3128 / 3288. After the PR: 96.88%  3197 / 3300.  This is based on:

```
$ CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test
…

$ grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html
```

PS. I guess if/once this lands I'll have to rebase https://github.com/RCasatta/qr_code/pull/19 again...  Oh well :-).

 