### PR TITLE
Improved (shortest-path-based) algorithm for finding optimal segmentation

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1846,15 +1846,15 @@ impl Canvas {
         let mut total_score = 0;
 
         for i in 0..self.width {
-            for j in 0..self.width - 6 {
-                // TODO a ref to a closure should be enough?
-                let get: Box<dyn Fn(i16) -> Color> = if is_horizontal {
-                    Box::new(|k| self.get(k, i).into())
+            let get = |k| -> Color {
+                if is_horizontal {
+                    self.get(k, i).into()
                 } else {
-                    Box::new(|k| self.get(i, k).into())
-                };
-
-                if (j..(j + 7)).map(&*get).ne(PATTERN.iter().cloned()) {
+                    self.get(i, k).into()
+                }
+            };
+            for j in 0..self.width - 6 {
+                if (j..(j + 7)).map(get).ne(PATTERN.iter().cloned()) {
                     continue;
                 }
 

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -116,7 +116,7 @@ mod tests {
         let data = include_bytes!(
             "../fuzz/artifacts/encode/crash-9ffe42701f80d18e9c114f1134b9d64045f7d5ce"
         );
-        assert!(crate::QrCode::new(data).is_err());
+        assert!(crate::QrCode::new(data).is_ok());
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -631,8 +631,13 @@ pub fn optimize_segmentation(segments: &[Segment], version: Version) -> Vec<Segm
         return Vec::new();
     }
 
-    shortest_path::AlgorithmState::find_shortest_paths(segments, version)
-        .construct_best_segmentation()
+    let optimized_segments = shortest_path::AlgorithmState::find_shortest_paths(segments, version)
+        .construct_best_segmentation();
+
+    #[cfg(fuzzing)]
+    optimize_test_helpers::assert_valid_optimization(&segments, &*optimized_segments, version);
+
+    optimized_segments
 }
 
 /// Computes the total encoded length of all segments.
@@ -647,15 +652,15 @@ where
         .sum()
 }
 
-#[cfg(test)]
-mod optimize_tests {
-    use super::{assert_valid_segmentation, optimize_segmentation, total_encoded_len, Segment};
+#[cfg(any(fuzzing, test))]
+mod optimize_test_helpers {
+    use super::{assert_valid_segmentation, total_encoded_len, Segment};
     use crate::types::{Mode, Version};
     use std::cmp::Ordering;
 
     /// Panics if there exists an input that can be represented by `given` segments,
     /// but that cannot be represented by `opt` segments.
-    fn assert_segmentation_equivalence(given: &[Segment], opt: &[Segment]) {
+    pub fn assert_segmentation_equivalence(given: &[Segment], opt: &[Segment]) {
         if given.is_empty() {
             assert!(opt.is_empty());
             return;
@@ -693,39 +698,60 @@ mod optimize_tests {
         }
     }
 
+    /// Panics if `optimized` is not an improved representation of `input`.
+    pub fn assert_valid_optimization(input: &[Segment], optimized: &[Segment], version: Version) {
+        assert_valid_segmentation(input);
+        assert_valid_segmentation(optimized);
+        assert_segmentation_equivalence(input, optimized);
+
+        let input_len = total_encoded_len(input, version);
+        let optimized_len = total_encoded_len(optimized, version);
+        assert!(optimized_len <= input_len);
+
+        let single_bytes_segment_len = if input.is_empty() {
+            0
+        } else {
+            Segment {
+                begin: input.first().unwrap().begin,
+                end: input.last().unwrap().end,
+                mode: Mode::Byte,
+            }
+            .encoded_len(version)
+        };
+        assert!(optimized_len <= single_bytes_segment_len);
+    }
+}
+
+#[cfg(test)]
+mod optimize_tests {
+    use super::optimize_test_helpers::*;
+    use super::{assert_valid_segmentation, optimize_segmentation, total_encoded_len, Segment};
+    use crate::types::{Mode, Version};
+    use std::cmp::Ordering;
+
     fn test_optimization_result(given: Vec<Segment>, expected: Vec<Segment>, version: Version) {
         // Verify that the test input is valid.
-        assert_valid_segmentation(&*given);
+        assert_valid_segmentation(&given);
 
         // Verify that the test expectations are compatible with the test input.
-        assert_valid_segmentation(&*expected);
-        assert_segmentation_equivalence(&*given, &*expected);
+        assert_valid_segmentation(&expected);
+        assert_segmentation_equivalence(&given, &expected);
 
         let opt_segs = optimize_segmentation(given.as_slice(), version);
-
-        // Verify that the optimized segments are valid and can represent any input that
-        // the `given` segments can.
-        assert_valid_segmentation(&*opt_segs);
-        assert_segmentation_equivalence(&*given, &*opt_segs);
-
-        // Verify that optimization always produces a shorter result.
-        let prev_len = total_encoded_len(&*given, version);
-        let new_len = total_encoded_len(&*opt_segs, version);
-        if given != opt_segs {
-            assert!(prev_len > new_len, "{} > {}", prev_len, new_len);
-        }
+        assert_valid_optimization(&given, &opt_segs, version);
 
         // Verify that optimization produces result that is as short as `expected`.
         if opt_segs != expected {
+            let actual_len = total_encoded_len(&opt_segs, version);
             let expected_len = total_encoded_len(&expected, version);
-            let msg = match new_len.cmp(&expected_len) {
+            let msg = match actual_len.cmp(&expected_len) {
                 Ordering::Less => "Optimization gave something better than expected",
                 Ordering::Equal => "Optimization gave something different, but just as short",
                 Ordering::Greater => "Optimization gave something worse than expected",
             };
             panic!(
-                "{}: expected_len={}; optimized_len={}; opt_segs=({:?})",
-                msg, expected_len, new_len, opt_segs
+                "{}: expected_len={}; actual_len={}; opt_segs=({:?})",
+                msg, expected_len, actual_len, opt_segs
             );
         }
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -36,6 +36,16 @@ impl Segment {
 
         mode_bits_count + length_bits_count + data_bits_count
     }
+
+    /// Panics if `&self` is not a valid segment.
+    #[cfg(test)]
+    fn assert_invariants(&self) {
+        // TODO: It would be great if it would be impossible to construct an invalid `Segment` -
+        // either by 1) making the fields private and only allowing construction via a public,
+        // preconditions-checking API, or 2) keeping the fields public but replacing `end: usize`
+        // with `len: NonZeroUsize`.
+        assert!(self.begin < self.end);
+    }
 }
 
 //}}}
@@ -469,21 +479,102 @@ where
 mod optimize_tests {
     use crate::optimize::{total_encoded_len, Optimizer, Segment};
     use crate::types::{Mode, Version};
+    use std::cmp::Ordering;
+
+    /// Panics if `segments` are not consecutive (i.e. if there are gaps, or overlaps, or if the
+    /// segments are not ordered by their `begin` field).
+    fn assert_valid_segmentation(segments: &[Segment]) {
+        if segments.is_empty() {
+            return;
+        }
+
+        for segment in segments.iter() {
+            segment.assert_invariants();
+        }
+
+        let consecutive_pairs = segments[..(segments.len() - 1)]
+            .iter()
+            .zip(segments[1..].iter());
+        for (prev, next) in consecutive_pairs {
+            assert_eq!(prev.end, next.begin);
+        }
+    }
+
+    /// Panics if there exists an input that can be represented by `given` segments,
+    /// but that cannot be represented by `opt` segments.
+    fn assert_segmentation_equivalence(given: &[Segment], opt: &[Segment]) {
+        if given.is_empty() {
+            assert!(opt.is_empty());
+            return;
+        }
+        let begin = given.first().unwrap().begin;
+        let end = given.last().unwrap().end;
+
+        // Verify that `opt` covers the same range as `given`.
+        // (This assumes that contiguous coverage has already been verified by
+        // `assert_valid_segmentation`.)
+        assert!(!opt.is_empty());
+        assert_eq!(begin, opt.first().unwrap().begin);
+        assert_eq!(end, opt.last().unwrap().end);
+
+        // Verify that for each character, `opt` can represent all the characters that may be
+        // present in `given`.
+        for i in begin..end {
+            fn find_mode(segments: &[Segment], i: usize) {
+                segments
+                    .iter()
+                    .filter(|s| (s.begin <= i) && (i < s.end))
+                    .next()
+                    .expect("Expecting exactly one segment")
+                    .mode;
+            }
+            let given_mode = find_mode(&*given, i);
+            let opt_mode = find_mode(&*given, i);
+            match given_mode.partial_cmp(&opt_mode) {
+                Some(Ordering::Less | Ordering::Equal) => (),
+                _ => panic!(
+                    "Character #{} is {:?}, which {:?} may not represent",
+                    i, given_mode, opt_mode,
+                ),
+            }
+        }
+    }
 
     fn test_optimization_result(given: Vec<Segment>, expected: Vec<Segment>, version: Version) {
-        let prev_len = total_encoded_len(&given, version);
+        // Verify that the test input is valid.
+        assert_valid_segmentation(&*given);
+
+        // Verify that the test expectations are compatible with the test input.
+        assert_valid_segmentation(&*expected);
+        assert_segmentation_equivalence(&*given, &*expected);
+
         let opt_segs = Optimizer::new(given.iter().copied(), version).collect::<Vec<_>>();
-        let new_len = total_encoded_len(&opt_segs, version);
+
+        // Verify that the optimized segments are valid and can represent any input that
+        // the `given` segments can.
+        assert_valid_segmentation(&*opt_segs);
+        assert_segmentation_equivalence(&*given, &*opt_segs);
+
+        // Verify that optimization always produces a shorter result.
+        let prev_len = total_encoded_len(&*given, version);
+        let new_len = total_encoded_len(&*opt_segs, version);
         if given != opt_segs {
             assert!(prev_len > new_len, "{} > {}", prev_len, new_len);
         }
-        assert!(
-            opt_segs == expected,
-            "Optimization gave something better: {} < {} ({:?})",
-            new_len,
-            total_encoded_len(&expected, version),
-            opt_segs
-        );
+
+        // Verify that optimization produces result that is as short as `expected`.
+        if opt_segs != expected {
+            let expected_len = total_encoded_len(&expected, version);
+            let msg = match new_len.cmp(&expected_len) {
+                Ordering::Less => "Optimization gave something better than expected",
+                Ordering::Equal => "Optimization gave something different, but just as short",
+                Ordering::Greater => "Optimization gave something worse than expected",
+            };
+            panic!(
+                "{}: expected_len={}; optimized_len={}; opt_segs=({:?})",
+                msg, expected_len, new_len, opt_segs
+            );
+        }
     }
 
     #[test]
@@ -630,6 +721,170 @@ mod optimize_tests {
                 },
             ],
             Version::Normal(1),
+        );
+    }
+
+    #[test]
+    fn test_empty() {
+        test_optimization_result(vec![], vec![], Version::Normal(1));
+    }
+
+    /// This example shows that greedy merging strategy (used by `qr_code` v1.1.0) can give
+    /// suboptimal results for the following input: `"bytesbytesA1B2C3D4E5"`.  The greedy strategy
+    /// will always consider it (locally) beneficial to merge the initial `Mode::Byte` segment with
+    /// the subsequent single-char segment - this will result in representing the whole input
+    /// in a single `Mode::Byte` segment.  Better segmentation can be done by first merging all the
+    /// `Mode::Alphanumeric` and `Mode::Numeric` segments.
+    #[ignore]
+    #[test]
+    fn test_example_where_greedy_merging_is_suboptimal() {
+        let mut input = vec![Segment {
+            mode: Mode::Byte,
+            begin: 0,
+            end: 10,
+        }];
+        for _ in 0..5 {
+            for &mode in [Mode::Alphanumeric, Mode::Numeric].iter() {
+                let begin = input.last().unwrap().end;
+                let end = begin + 1;
+                input.push(Segment { mode, begin, end });
+            }
+        }
+        test_optimization_result(
+            input,
+            vec![
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 0,
+                    end: 10,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 10,
+                    end: 20,
+                },
+            ],
+            Version::Normal(40),
+        );
+    }
+
+    /// In this example merging 2 consecutive segments is always harmful, but merging many segments
+    /// may be beneficial.  This is because merging more than 2 segments saves additional header
+    /// bytes.
+    #[ignore]
+    #[test]
+    fn test_example_where_merging_two_consecutive_segments_is_always_harmful() {
+        let mut input = vec![];
+        for _ in 0..5 {
+            for &mode in [Mode::Byte, Mode::Alphanumeric].iter() {
+                let begin = input.last().map(|s: &Segment| s.end).unwrap_or_default();
+                let end = begin + 10;
+                input.push(Segment { mode, begin, end });
+            }
+        }
+        test_optimization_result(
+            input,
+            vec![
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 0,
+                    end: 90,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 90,
+                    end: 100,
+                },
+            ],
+            Version::Normal(40),
+        );
+    }
+
+    #[ignore]
+    #[test]
+    fn test_optimize_base64() {
+        let input: &[u8] = include_bytes!("../test_data/large_base64.in");
+        let input: Vec<Segment> = super::Parser::new(input).collect();
+        test_optimization_result(
+            input,
+            vec![
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 0,
+                    end: 334,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 334,
+                    end: 349,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 349,
+                    end: 387,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 387,
+                    end: 402,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 402,
+                    end: 850,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 850,
+                    end: 866,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 866,
+                    end: 1146,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 1146,
+                    end: 1162,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 1162,
+                    end: 2474,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 2474,
+                    end: 2489,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 2489,
+                    end: 2618,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 2618,
+                    end: 2641,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 2641,
+                    end: 2707,
+                },
+                Segment {
+                    mode: Mode::Alphanumeric,
+                    begin: 2707,
+                    end: 2722,
+                },
+                Segment {
+                    mode: Mode::Byte,
+                    begin: 2722,
+                    end: 2880,
+                },
+            ],
+            Version::Normal(40),
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -284,6 +284,9 @@ impl Mode {
             None => Mode::Byte,
         }
     }
+
+    pub(crate) const ALL_MODES: &'static [Mode] =
+        &[Mode::Numeric, Mode::Alphanumeric, Mode::Byte, Mode::Kanji];
 }
 
 impl PartialOrd for Mode {


### PR DESCRIPTION
@RCasatta, can you PTAL?

This is a rather large PR.  Sorry.  Feel free to take your time.

FWIW, profiling shows that there might still be considerable performance gain opportunities in `compute_finder_penalty_score` (35% of the total `QrCode::new` time;  currently substring search is implemented as O(N x M) instead of O(N + M) time), and maybe `compute_adjacent_penalty_score` (31.9%) and `compute_block_penalty_score` (16.5%).  Maybe I should open a separate issue to capture this profiler/performance analysis?

I think the PR should be in a reasonable overall shape.  IMO the most fiddly bits of this PR are:

* The public API change.
    * It is not technically necessary, but it still seems desirable in the long-term:
        * I feel that the new API most accurately expresses the API contract - consuming a finite-length slice + returning a `Vec`;  using `Iterator` as input or output would feel misleading.
        * Preserving the old API would feel hackish (we could take an `Iterator` as input and immediately consume it into a `Vec`;  and instead of directly returning a `Vec` we could wrap it in a `Optimizer` (or renaming to `Optimized?`) struct that implements iterating over the wrapped, precomputed vector)
    * I guess I could extract the API change into a separate commit.  I wasn't sure if this is desirable (since the  API is quite tightly coupled with the algorithm change).  Please shout if you'd like a separate commit.
* The timeout checks in `test_very_large_input` feel rather ad-hoc, but it seems that native Rust tests don't support a different/better way to do it.
* The fuzzing-only assertions in the last commit also feel a bit ad-hoc.  OTOH, having fuzzing coverage *with* the new assertions (and running the fuzzer for a few days) helped me to significantly increase my confidence that there are no hidden/remaining issues in the new algorithm.

Thank you for your time :-)